### PR TITLE
use -nologo option for VC Perl (nmake) builds

### DIFF
--- a/t/lib/Helper.pm
+++ b/t/lib/Helper.pm
@@ -6,6 +6,12 @@ use Test::Fatal ();
 use Path::Tiny ();
 use File::pushd ();
 use Capture::Tiny ();
+use Config;
+
+# Microsoft nmake outputs a copyright message that
+# messes up the output checks, but we can work around
+# this by setting the -nologo option using MAKEFLAGS
+$ENV{MAKEFLAGS} = 'nologo' if $Config{make} eq 'nmake';
 
 sub run_makemaker
 {

--- a/t/lib/Helper.pm
+++ b/t/lib/Helper.pm
@@ -11,7 +11,7 @@ use Config;
 # Microsoft nmake outputs a copyright message that
 # messes up the output checks, but we can work around
 # this by setting the -nologo option using MAKEFLAGS
-$ENV{MAKEFLAGS} = 'nologo' if $Config{make} eq 'nmake';
+$ENV{MAKEFLAGS} = join(' ', 'nologo', ($ENV{MAKEFLAGS} // ())) if $Config{make} eq 'nmake';
 
 sub run_makemaker
 {


### PR DESCRIPTION
Visual C++ builds of Perl normally use nmake (other builds can too though I think this is fairly uncommon today).  Unfortunately nmake outputs a copyright message by default before doing anything and this can cause the tests for [DynamicPrereqs] to fail as they rely on silent make output. This patch adds the -nologo option in the helper so individual tests do not have to set it.

This seems to be a good way to address rt#131185.

I played around with `!CMDSWITCHES` but it seems to disallow `-nologo` in the two contexts under which that can be used.  I think checking `$Config{make}` for the value of `nmake` should work, although I am happy to rework any of this to taste and test it with VC++ Perl as needed.