### PR TITLE
add want_xs included sub

### DIFF
--- a/lib/Dist/Zilla/Plugin/DynamicPrereqs.pm
+++ b/lib/Dist/Zilla/Plugin/DynamicPrereqs.pm
@@ -342,6 +342,7 @@ my %sub_dependencies = (
     build_requires => [ qw(_add_prereq) ],
     test_requires => [ qw(_add_prereq) ],
     want_pp => [ qw(parse_args) ],
+    want_xs => [ qw(want_pp can_xs) ],
 );
 
 has _all_required_subs => (
@@ -612,6 +613,9 @@ Available subs are:
   (indicating that no XS-requiring modules or code should be installed). false if
   the user has explicitly specified C<PUREPERL_ONLY> as 0. undef if no preference
   was specified.
+
+* C<want_xs()> - true if C<PUREPERL_ONLY> was specified as 0, or if it was not
+  specified and compiling XS modules is possible (checked via can_xs).
 
 =end :list
 

--- a/lib/Dist/Zilla/Plugin/DynamicPrereqs.pm
+++ b/lib/Dist/Zilla/Plugin/DynamicPrereqs.pm
@@ -608,8 +608,10 @@ Available subs are:
   prereqs (as a shorthand for editing the hashes in F<Makefile.PL> directly).
   Added in 0.016.
 
-* C<want_pp> - true if the user or CPAN client explicitly specified PUREPERL_ONLY
-  (indicating that no XS-requiring modules or code should be installed)
+* C<want_pp()> - true if the user or CPAN client explicitly specified C<PUREPERL_ONLY>
+  (indicating that no XS-requiring modules or code should be installed). false if
+  the user has explicitly specified C<PUREPERL_ONLY> as 0. undef if no preference
+  was specified.
 
 =end :list
 

--- a/share/DynamicPrereqs/include_subs/want_pp
+++ b/share/DynamicPrereqs/include_subs/want_pp
@@ -1,7 +1,10 @@
 {
   my $want_pp;
   sub want_pp {
-    return $want_pp if defined $want_pp;
-    $want_pp = parse_args()->{PUREPERL_ONLY} ? 1 : 0
+    return $$want_pp if defined $want_pp;
+    my $pp_only = parse_args()->{PUREPERL_ONLY};
+    $pp_only = !!$pp_only if defined $pp_only;
+    $want_pp = \$pp_only;
+    $pp_only;
   }
 }

--- a/share/DynamicPrereqs/include_subs/want_xs
+++ b/share/DynamicPrereqs/include_subs/want_xs
@@ -1,0 +1,10 @@
+{
+  my $want_xs;
+  sub want_xs {
+    return $want_xs if defined $want_xs;
+    my $want_pp = want_pp();
+    $want_xs = defined $want_pp ? !$want_pp : can_xs();
+    return $want_xs;
+  }
+}
+


### PR DESCRIPTION
This combines the checks for want_pp and can_xs in the way that they
should most commonly be used.

The return from want_pp is adjusted to return undef when PUREPERL_ONLY is not specified. This means setting PUREPERL_ONLY to 0 can be checked for, and will prefer XS without doing a compiler check.